### PR TITLE
Fix problem finding loop0p2 after parted

### DIFF
--- a/.github/workflows/test-opi.yml
+++ b/.github/workflows/test-opi.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           image_url: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v2.4.0/ubuntu-24.04-preinstalled-server-arm64-orangepi-5.img.xz
           additional_mb: 200
-          minimum_free_mb: 500
+          minimum_free_mb: 2000
           commands: |
               echo "Testing Orange Pi image"
               lsblk

--- a/.github/workflows/test-opi.yml
+++ b/.github/workflows/test-opi.yml
@@ -1,0 +1,40 @@
+name: 'Test modifying a Orange Pi image'
+on:
+  push:
+    branches:
+      - 'main'
+      - 'releases/**'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./  # photonvision/photon-image-runner@HEAD
+        with:
+          image_url: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v2.4.0/ubuntu-24.04-preinstalled-server-arm64-orangepi-5.img.xz
+          additional_mb: 200
+          minimum_free_mb: 500
+          commands: |
+              echo "Testing Orange Pi image"
+              lsblk
+              echo "${loopdev}"
+              echo "/boot contents:"
+              ls -la /boot
+              touch /boot/photon-image-modifier-was-here
+        id: build_image
+      - name: Compress image
+        run: |
+            sudo xz -T 0 -v -k ${{ steps.build_image.outputs.image }}
+            
+      - uses: actions/upload-artifact@v6
+        with:
+          name: raspi.img.xz
+          path: ${{ steps.build_image.outputs.image }}.xz
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+
+

--- a/mount_image.sh
+++ b/mount_image.sh
@@ -82,6 +82,7 @@ if [[ ${additional_mb} -gt 0 ]]; then
     fi
     if [[ ${rootpartition} -gt 0 ]]; then
         parted --script "${loopdev}" resizepart ${rootpartition} 100%
+        sync
         e2fsck -p -f "${rootdev}"
         resize2fs "${rootdev}"
     fi


### PR DESCRIPTION
Occasionally, builds fail with a message that e2fsck can't open /dev/loop0p2. This oocurs after resizing the partition with parted.

```
+ parted --script /dev/loop0 resizepart 2 100%
+ e2fsck -p -f /dev/loop0p2
e2fsck: No such file or directory while trying to open /dev/loop0p2
Possibly non-existent device?
Error: Process completed with exit code 8.
```

There may be a race condition, so adding sync after parted could help.