### PR TITLE
Remove all references to boot_partition

### DIFF
--- a/.github/workflows/test-rubikpi.yml
+++ b/.github/workflows/test-rubikpi.yml
@@ -22,7 +22,6 @@ jobs:
           root_location: "offset=569376768"
           shrink_image: "no"
           use_cache: "yes"
-          boot_partition: ""
           commands: |
               echo "Testing Rubik Pi image from .yaml"
               uname -a
@@ -39,7 +38,6 @@ jobs:
           root_location: "offset=569376768"
           shrink_image: "no"
           use_cache: "yes"
-          boot_partition: ""
           commands: |
               echo "Testing file access Rubik Pi image"
               uname -a

--- a/.github/workflows/test-standard-images.yml
+++ b/.github/workflows/test-standard-images.yml
@@ -32,7 +32,6 @@ jobs:
           image_url: "${{ matrix.base_image }}"
           additional_mb: 200
           minimum_free_mb: 500
-          boot_partition: ""
           use_cache: "yes"
           commands: |
               echo "Testing $(basename ${{ matrix.base_image }}) image"
@@ -48,7 +47,6 @@ jobs:
         with:
           image_url: "file://${{ steps.test_download_image.outputs.image }}"
           minimum_free_mb: 500
-          boot_partition: ""
           use_cache: "yes"
           commands: |
               echo "Testing file access to ${{ steps.test_download_image.outputs.image }} image"

--- a/.github/workflows/test-tar.yml
+++ b/.github/workflows/test-tar.yml
@@ -20,7 +20,6 @@ jobs:
           image_url: https://github.com/PhotonVision/photon-image-modifier/releases/download/v2027.0.0/photonvision_rubikpi3.tar.xz
           minimum_free_mb: 2000
           root_location: "offset=569376768"
-          boot_partition: ""
           shrink_image: "no"
           use_cache: "yes"
           commands: |
@@ -37,7 +36,6 @@ jobs:
         with:
           image_url: "file://${{ steps.test_download_image.outputs.image }}"
           root_location: "offset=569376768"
-          boot_partition: ""
           shrink_image: "no"
           use_cache: "yes"
           commands: |

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,6 @@ inputs:
     description: 'The commands to run in the image'
     required: true
     default: 'echo "No commands provided"'
-  boot_partition:
-    description: '[DEPRECATED] Partition number for boot, will be mounted at /boot'
-    required: false
-    default: '1'
   root_location:
     description: 'Location of the root as either "partition=X" or "offset=XXX"'
     required: false
@@ -68,7 +64,7 @@ runs:
 
     - name: Mount image
       run: |
-          sudo --preserve-env bash "${GITHUB_ACTION_PATH}/mount_image.sh" "${{ steps.get_image.outputs.image }}" "${{ inputs.additional_mb }}" "${{ inputs.minimum_free_mb }}" "${{ inputs.root_location }}" "${{ inputs.boot_partition }}"
+          sudo --preserve-env bash "${GITHUB_ACTION_PATH}/mount_image.sh" "${{ steps.get_image.outputs.image }}" "${{ inputs.additional_mb }}" "${{ inputs.minimum_free_mb }}" "${{ inputs.root_location }}"
       shell: bash
       id: mount_image
 

--- a/mount_image.sh
+++ b/mount_image.sh
@@ -5,7 +5,6 @@ image="$1"
 additional_mb=$2
 minimum_free=$3
 root_location=$4
-bootpartition=$5
 
 ####
 # Prepare and mount the image
@@ -14,19 +13,11 @@ bootpartition=$5
 case "${root_location,,}" in
     partition* )
         rootpartition=${root_location#*=}
-        if [[ "${rootpartition}" = "${bootpartition}" ]]; then
-            echo "Boot partition cannot be equal to root partition"
-            if [ "${bootpartition}" = "1" ]; then
-                echo "Forgot to unset bootpartition ?"
-            fi
-            exit 1
-        fi
         loopdev=$(losetup --find --show --partscan ${image})
         rootdev="${loopdev}p${rootpartition}"
     ;;
     offset* )
         rootpartition=0
-        bootpartition=
         rootoffset=${root_location#*=}
         loopdev=$(losetup --find --show --offset=${rootoffset} ${image})
         rootdev="${loopdev}"
@@ -37,18 +28,10 @@ case "${root_location,,}" in
     ;;
 esac
 
-if [[ -n "${bootpartition}" ]]; then
-    bootdev="${loopdev}p${bootpartition}"
-else
-    bootdev=
-fi   
-
 echo "loopdev=${loopdev}" >> "$GITHUB_ENV"
 echo "rootpartition=${rootpartition}" >> "$GITHUB_ENV"
 echo "rootdev=${rootdev}" >> "$GITHUB_ENV"
-echo "bootdev=${bootdev}" >> "$GITHUB_ENV"
 echo "Root device is: ${rootdev}"
-echo "Boot device is: ${bootdev:-UNSET}"
 
 echo "Partitions in the mounted image:"
 lsblk "${loopdev}"
@@ -98,11 +81,6 @@ lsblk "${loopdev}"
 mount "${rootdev}" "${rootdir}"
 echo "rootdir=${rootdir}" >> "$GITHUB_ENV"
 echo "Root directory is: ${rootdir}"
-
-if [[ -n "${bootdev}" ]]; then
-    [ ! -d "${rootdir}/boot" ] && mkdir "${rootdir}/boot"
-    mount "${bootdev}" "${rootdir}/boot"
-fi
 
 echo "Space in root directory:"
 df --block-size=M "${rootdir}"

--- a/pack_image.sh
+++ b/pack_image.sh
@@ -11,12 +11,6 @@ if [[ -e "${rootdir}/etc/resolv.conf.bak" ]]; then
     mv "${rootdir}/etc/resolv.conf.bak" "${rootdir}/etc/resolv.conf"
 fi
 
-if [[ -n "${bootdev}" ]]; then
-    echo "Zero filling empty space on boot partition"
-    (cat /dev/zero > "${rootdir}/boot/zeros" 2>/dev/null || true); sync; rm "${rootdir}/boot/zeros";
-    umount "${rootdir}/boot"
-fi
-
 echo "Zero filling empty space"
 (cat /dev/zero > "${rootdir}/zeros" 2>/dev/null || true); sync; rm "${rootdir}/zeros";
 


### PR DESCRIPTION
Earlier versions of photon-image-runner included an option to mount a second "boot" partition at `/boot`. In the past, this was how Raspbian was set up, but that is no longer the case and it isn't correct for images for other coprocessors such as the OrangePi or RubikPi Ubuntu images.

This PR removes the option and leaves it up to the user if, and where they want to mount additional partitions.

This is a breaking change.